### PR TITLE
Remove use of Req.request

### DIFF
--- a/lib/pinecone/http.ex
+++ b/lib/pinecone/http.ex
@@ -22,23 +22,14 @@ defmodule Pinecone.Http do
 
     type
     |> url(endpoint, config[:environment])
-    |> then(
-      &Req.request(url: &1, params: params, method: :delete, headers: headers(config[:api_key]))
-    )
+    |> Req.delete(params: params, headers: headers(config[:api_key]))
     |> parse_response()
   end
 
   def patch(type, endpoint, body, config \\ []) do
     type
     |> url(endpoint, config[:environment])
-    |> then(
-      &Req.request(
-        url: &1,
-        body: Jason.encode!(body),
-        method: :patch,
-        headers: headers(config[:api_key])
-      )
-    )
+    |> Req.patch(body: Jason.encode!(body), headers: headers(config[:api_key]))
     |> parse_response()
   end
 


### PR DESCRIPTION
Removed `Req.request` for `delete` and `patch` methods in favor of `Req.delete` and `Req.patch`

Ref. https://hexdocs.pm/req/Req.html#delete/2 and https://hexdocs.pm/req/Req.html#patch/2

Did not test it myself, but according to that documentation, this should work just fine. 